### PR TITLE
fix: update Dockerfile to run Python in unbuffered mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,4 +15,7 @@ RUN useradd -m botuser && \
     chown -R botuser:botuser /app
 USER botuser
 
-CMD ["python", "main.py"] 
+# Run Python in unbuffered mode
+ENV PYTHONUNBUFFERED=1
+
+CMD ["python", "-u", "main.py"] 


### PR DESCRIPTION
- Set the environment variable PYTHONUNBUFFERED to 1 for better logging.
- Updated the CMD instruction to run Python in unbuffered mode, improving output handling.